### PR TITLE
Chat history interface

### DIFF
--- a/LLama.Examples/Examples/ChatChineseGB2312.cs
+++ b/LLama.Examples/Examples/ChatChineseGB2312.cs
@@ -105,7 +105,7 @@ public class ChatChineseGB2312
                 await foreach (
                     var text
                     in session.ChatAsync(
-                        new ChatHistory.Message(AuthorRole.User, userInput),
+                        new Message(AuthorRole.User, userInput),
                         inferenceParams))
                 {
                     Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Examples/Examples/ChatChineseGB2312.cs
+++ b/LLama.Examples/Examples/ChatChineseGB2312.cs
@@ -49,13 +49,13 @@ public class ChatChineseGB2312
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-kunkun-chinese.json");
-            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
+            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson, typeof(ChatHistory)) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }
 
         session
-            .WithHistoryTransform(new LLamaTransforms.DefaultHistoryTransform<ChatHistory>("用户", "坤坤"));
+            .WithHistoryTransform(new LLamaTransforms.DefaultHistoryTransform("用户", "坤坤"));
 
         InferenceParams inferenceParams = new InferenceParams()
         {

--- a/LLama.Examples/Examples/ChatChineseGB2312.cs
+++ b/LLama.Examples/Examples/ChatChineseGB2312.cs
@@ -49,7 +49,7 @@ public class ChatChineseGB2312
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-kunkun-chinese.json");
-            ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+            ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }

--- a/LLama.Examples/Examples/ChatChineseGB2312.cs
+++ b/LLama.Examples/Examples/ChatChineseGB2312.cs
@@ -49,13 +49,13 @@ public class ChatChineseGB2312
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-kunkun-chinese.json");
-            ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
+            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }
 
         session
-            .WithHistoryTransform(new LLamaTransforms.DefaultHistoryTransform("用户", "坤坤"));
+            .WithHistoryTransform(new LLamaTransforms.DefaultHistoryTransform<ChatHistory>("用户", "坤坤"));
 
         InferenceParams inferenceParams = new InferenceParams()
         {

--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -46,7 +46,7 @@ public class ChatSessionStripRoleName
             await foreach (
                 var text
                 in session.ChatAsync(
-                    new ChatHistory.Message(AuthorRole.User, userInput),
+                    new Message(AuthorRole.User, userInput),
                     inferenceParams))
             {
                 Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -21,7 +21,7 @@ public class ChatSessionStripRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
         session.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(

--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -21,7 +21,7 @@ public class ChatSessionStripRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
         session.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(

--- a/LLama.Examples/Examples/ChatSessionStripRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionStripRoleName.cs
@@ -21,7 +21,7 @@ public class ChatSessionStripRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson, typeof(ChatHistory)) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
         session.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -92,7 +92,7 @@ public class ChatSessionWithHistory
                 await foreach (
                     var text
                     in session.ChatAsync(
-                        new ChatHistory.Message(AuthorRole.User, userInput),
+                        new Message(AuthorRole.User, userInput),
                         inferenceParams))
                 {
                     Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -31,7 +31,7 @@ public class ChatSessionWithHistory
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
+            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson, typeof(ChatHistory)) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -31,7 +31,7 @@ public class ChatSessionWithHistory
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-            ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+            ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }

--- a/LLama.Examples/Examples/ChatSessionWithHistory.cs
+++ b/LLama.Examples/Examples/ChatSessionWithHistory.cs
@@ -31,7 +31,7 @@ public class ChatSessionWithHistory
         else
         {
             var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-            ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
+            IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
 
             session = new ChatSession(executor, chatHistory);
         }

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRestart
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson, typeof(ChatHistory)) ?? new ChatHistory();
         ChatSession prototypeSession =
             await ChatSession.InitializeSessionFromHistoryAsync(executor, chatHistory);
         prototypeSession.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(
@@ -53,7 +53,7 @@ public class ChatSessionWithRestart
             if (userInput == "reset")
             {
                 session.LoadSession(resetState);
-                Console.WriteLine($"Reset to history:\n{session.HistoryTransform.HistoryToText(session.History)}");
+                Console.WriteLine($"Reset to history:\n{session.HistoryTransform.HistoryToText(session.SessionChatHistory)}");
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Session reset.");
             }

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRestart
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
         ChatSession prototypeSession =
             await ChatSession.InitializeSessionFromHistoryAsync(executor, chatHistory);
         prototypeSession.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -20,7 +20,7 @@ public class ChatSessionWithRestart
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
         ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
-        ChatSession prototypeSession = 
+        ChatSession prototypeSession =
             await ChatSession.InitializeSessionFromHistoryAsync(executor, chatHistory);
         prototypeSession.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(
             new string[] { "User:", "Assistant:" },
@@ -50,7 +50,7 @@ public class ChatSessionWithRestart
         while (userInput != "exit")
         {
             // Load the session state from the reset state
-            if(userInput == "reset")
+            if (userInput == "reset")
             {
                 session.LoadSession(resetState);
                 Console.WriteLine($"Reset to history:\n{session.HistoryTransform.HistoryToText(session.History)}");
@@ -75,10 +75,10 @@ public class ChatSessionWithRestart
 
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Provide assistant input: ");
-                
+
                 Console.ForegroundColor = ConsoleColor.Green;
                 string assistantInputOverride = Console.ReadLine() ?? "";
-                
+
                 await session.AddAndProcessUserMessage(userInputOverride);
                 await session.AddAndProcessAssistantMessage(assistantInputOverride);
 
@@ -90,7 +90,7 @@ public class ChatSessionWithRestart
                 await foreach (
                     var text
                     in session.ChatAsync(
-                        new ChatHistory.Message(AuthorRole.User, userInput),
+                        new Message(AuthorRole.User, userInput),
                         inferenceParams))
                 {
                     Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Examples/Examples/ChatSessionWithRestart.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRestart.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRestart
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
         ChatSession prototypeSession =
             await ChatSession.InitializeSessionFromHistoryAsync(executor, chatHistory);
         prototypeSession.WithOutputTransform(new LLamaTransforms.KeywordTextOutputStreamTransform(

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson, typeof(ChatHistory)) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
 

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -41,7 +41,7 @@ public class ChatSessionWithRoleName
             await foreach (
                 var text
                 in session.ChatAsync(
-                    new ChatHistory.Message(AuthorRole.User, userInput),
+                    new Message(AuthorRole.User, userInput),
                     inferenceParams))
             {
                 Console.ForegroundColor = ConsoleColor.White;

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
+        IChatHistory chatHistory = ChatHistorySerializer.FromJson(chatHistoryJson) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
 

--- a/LLama.Examples/Examples/ChatSessionWithRoleName.cs
+++ b/LLama.Examples/Examples/ChatSessionWithRoleName.cs
@@ -19,7 +19,7 @@ public class ChatSessionWithRoleName
         var executor = new InteractiveExecutor(context);
 
         var chatHistoryJson = File.ReadAllText("Assets/chat-with-bob.json");
-        ChatHistory chatHistory = ChatHistory.FromJson(chatHistoryJson) ?? new ChatHistory();
+        ChatHistory chatHistory = ChatHistorySerializer<ChatHistory>.FromJson(chatHistoryJson) ?? new ChatHistory();
 
         ChatSession session = new(executor, chatHistory);
 

--- a/LLama.Examples/Examples/LoadAndSaveSession.cs
+++ b/LLama.Examples/Examples/LoadAndSaveSession.cs
@@ -33,7 +33,7 @@ namespace LLama.Examples.Examples
                 await foreach (
                     var text
                     in session.ChatAsync(
-                        new ChatHistory.Message(AuthorRole.User, prompt),
+                        new Message(AuthorRole.User, prompt),
                         new InferenceParams()
                         {
                             Temperature = 0.6f,

--- a/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
+++ b/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
@@ -7,7 +7,7 @@ namespace LLamaSharp.SemanticKernel.ChatCompletion;
 /// <summary>
 /// Default HistoryTransform Patch
 /// </summary>
-public class HistoryTransform : DefaultHistoryTransform<ChatHistory>
+public class HistoryTransform : DefaultHistoryTransform
 {
     /// <inheritdoc/>
     public string HistoryToText(global::LLama.Common.ChatHistory history)

--- a/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
+++ b/LLama.SemanticKernel/ChatCompletion/HistoryTransform.cs
@@ -7,10 +7,10 @@ namespace LLamaSharp.SemanticKernel.ChatCompletion;
 /// <summary>
 /// Default HistoryTransform Patch
 /// </summary>
-public class HistoryTransform : DefaultHistoryTransform
+public class HistoryTransform : DefaultHistoryTransform<ChatHistory>
 {
     /// <inheritdoc/>
-    public override string HistoryToText(global::LLama.Common.ChatHistory history)
+    public string HistoryToText(global::LLama.Common.ChatHistory history)
     {
         return base.HistoryToText(history) + $"{AuthorRole.Assistant}: ";
     }

--- a/LLama.WebAPI/Controllers/ChatController.cs
+++ b/LLama.WebAPI/Controllers/ChatController.cs
@@ -43,7 +43,7 @@ namespace LLama.WebAPI.Controllers
         {
             var history = new ChatHistory();
 
-            var messages = input.Messages.Select(m => new ChatHistory.Message(Enum.Parse<AuthorRole>(m.Role), m.Content));
+            var messages = input.Messages.Select(m => new Message(Enum.Parse<AuthorRole>(m.Role), m.Content));
 
             history.Messages.AddRange(messages);
 

--- a/LLama.WebAPI/Services/StatefulChatService.cs
+++ b/LLama.WebAPI/Services/StatefulChatService.cs
@@ -28,7 +28,7 @@ public class StatefulChatService : IDisposable
         _context = new LLamaContext(weights, @params);
 
         _session = new ChatSession(new InteractiveExecutor(_context));
-        _session.History.AddMessage(Common.AuthorRole.System, SystemPrompt);
+        _session.SessionChatHistory.AddMessage(Common.AuthorRole.System, SystemPrompt);
     }
 
     public void Dispose()

--- a/LLama.WebAPI/Services/StatefulChatService.cs
+++ b/LLama.WebAPI/Services/StatefulChatService.cs
@@ -46,7 +46,7 @@ public class StatefulChatService : IDisposable
         }
         _logger.LogInformation("Input: {text}", input.Text);
         var outputs = _session.ChatAsync(
-            new Common.ChatHistory.Message(Common.AuthorRole.User, input.Text),
+            new Common.Message(Common.AuthorRole.User, input.Text),
             new Common.InferenceParams()
             {
                 RepeatPenalty = 1.0f,
@@ -74,7 +74,7 @@ public class StatefulChatService : IDisposable
         _logger.LogInformation(input.Text);
 
         var outputs = _session.ChatAsync(
-            new Common.ChatHistory.Message(Common.AuthorRole.User, input.Text!)
+            new Common.Message(Common.AuthorRole.User, input.Text!)
             , new Common.InferenceParams()
             {
                 RepeatPenalty = 1.0f,

--- a/LLama.WebAPI/Services/StatelessChatService.cs
+++ b/LLama.WebAPI/Services/StatelessChatService.cs
@@ -46,12 +46,11 @@ namespace LLama.WebAPI.Services
 
         }
     }
-    public class HistoryTransform : DefaultHistoryTransform
+    public class HistoryTransform : DefaultHistoryTransform<ChatHistory>
     {
-        public override string HistoryToText(ChatHistory history)
+        public override string HistoryToText(IChatHistory history)
         {
             return base.HistoryToText(history) + "\n Assistant:";
         }
-
     }
 }

--- a/LLama.WebAPI/Services/StatelessChatService.cs
+++ b/LLama.WebAPI/Services/StatelessChatService.cs
@@ -46,7 +46,7 @@ namespace LLama.WebAPI.Services
 
         }
     }
-    public class HistoryTransform : DefaultHistoryTransform<ChatHistory>
+    public class HistoryTransform : DefaultHistoryTransform
     {
         public override string HistoryToText(IChatHistory history)
         {

--- a/LLama/Abstractions/IHistoryTransform.cs
+++ b/LLama/Abstractions/IHistoryTransform.cs
@@ -14,15 +14,15 @@ namespace LLama.Abstractions
         /// </summary>
         /// <param name="history">The ChatHistory instance</param>
         /// <returns></returns>
-        string HistoryToText(ChatHistory history);
-        
+        string HistoryToText(IChatHistory history);
+
         /// <summary>
         /// Converts plain text to a ChatHistory instance.
         /// </summary>
         /// <param name="role">The role for the author.</param>
         /// <param name="text">The chat history as plain text.</param>
         /// <returns>The updated history.</returns>
-        ChatHistory TextToHistory(AuthorRole role, string text);
+        IChatHistory TextToHistory(AuthorRole role, string text);
 
         /// <summary>
         /// Copy the transform.

--- a/LLama/Abstractions/IHistoryTransform.cs
+++ b/LLama/Abstractions/IHistoryTransform.cs
@@ -1,4 +1,5 @@
 ﻿using LLama.Common;
+using System;
 using System.Text.Json.Serialization;
 
 namespace LLama.Abstractions
@@ -21,8 +22,9 @@ namespace LLama.Abstractions
         /// </summary>
         /// <param name="role">The role for the author.</param>
         /// <param name="text">The chat history as plain text.</param>
+        /// <param name="type">The type of the chat history.</param>
         /// <returns>The updated history.</returns>
-        IChatHistory TextToHistory(AuthorRole role, string text);
+        IChatHistory TextToHistory(AuthorRole role, string text, Type type);
 
         /// <summary>
         /// Copy the transform.

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -686,7 +686,7 @@ public record SessionState
         File.WriteAllText(executorStateFilepath, JsonSerializer.Serialize(ExecutorState));
 
         string historyFilepath = Path.Combine(path, ChatSession.HISTORY_STATE_FILENAME);
-        File.WriteAllText(historyFilepath, new ChatHistory(History).ToJson());
+        File.WriteAllText(historyFilepath, ChatHistorySerializer<ChatHistory>.ToJson(new ChatHistory(History)));
 
         string inputTransformFilepath = Path.Combine(path, ChatSession.INPUT_TRANSFORM_FILENAME);
         File.WriteAllText(inputTransformFilepath, JsonSerializer.Serialize(InputTransformPipeline));
@@ -726,7 +726,7 @@ public record SessionState
 
         string historyFilepath = Path.Combine(path, ChatSession.HISTORY_STATE_FILENAME);
         string historyJson = File.ReadAllText(historyFilepath);
-        var history = ChatHistory.FromJson(historyJson)
+        var history = ChatHistorySerializer<ChatHistory>.FromJson(historyJson)
             ?? throw new ArgumentException("History file is invalid", nameof(path));
 
         string inputTransformFilepath = Path.Combine(path, ChatSession.INPUT_TRANSFORM_FILENAME);

--- a/LLama/ChatSession.cs
+++ b/LLama/ChatSession.cs
@@ -165,7 +165,7 @@ public class ChatSession
     {
         var executorState = ((StatefulExecutorBase)Executor).GetStateData();
         return new SessionState(
-            executorState.PastTokensCount > 0 
+            executorState.PastTokensCount > 0
             ? Executor.Context.GetState() : null,
             executorState,
             History,
@@ -221,7 +221,7 @@ public class ChatSession
         if (state.ExecutorState is null)
         {
             var executorPath = Path.Combine(path, EXECUTOR_STATE_FILENAME);
-            ((StatefulExecutorBase) Executor).LoadState(filename: executorPath); 
+            ((StatefulExecutorBase)Executor).LoadState(filename: executorPath);
         }
         LoadSession(state, loadTransforms);
     }
@@ -231,7 +231,7 @@ public class ChatSession
     /// </summary>
     /// <param name="message"></param>
     /// <returns></returns>
-    public ChatSession AddMessage(ChatHistory.Message message)
+    public ChatSession AddMessage(Message message)
     {
         // If current message is a system message, only allow the history to be empty
         if (message.AuthorRole == AuthorRole.System && History.Messages.Count > 0)
@@ -243,7 +243,7 @@ public class ChatSession
         // or the previous message to be a system message or assistant message.
         if (message.AuthorRole == AuthorRole.User)
         {
-            ChatHistory.Message? lastMessage = History.Messages.LastOrDefault();
+            Message? lastMessage = History.Messages.LastOrDefault();
             if (lastMessage is not null && lastMessage.AuthorRole == AuthorRole.User)
             {
                 throw new ArgumentException("Cannot add a user message after another user message", nameof(message));
@@ -254,7 +254,7 @@ public class ChatSession
         // the previous message must be a user message.
         if (message.AuthorRole == AuthorRole.Assistant)
         {
-            ChatHistory.Message? lastMessage = History.Messages.LastOrDefault();
+            Message? lastMessage = History.Messages.LastOrDefault();
             if (lastMessage is null
                 || lastMessage.AuthorRole != AuthorRole.User)
             {
@@ -272,7 +272,7 @@ public class ChatSession
     /// <param name="content"></param>
     /// <returns></returns>
     public ChatSession AddSystemMessage(string content)
-        => AddMessage(new ChatHistory.Message(AuthorRole.System, content));
+        => AddMessage(new Message(AuthorRole.System, content));
 
     /// <summary>
     /// Add an assistant message to the chat history.
@@ -280,7 +280,7 @@ public class ChatSession
     /// <param name="content"></param>
     /// <returns></returns>
     public ChatSession AddAssistantMessage(string content)
-        => AddMessage(new ChatHistory.Message(AuthorRole.Assistant, content));
+        => AddMessage(new Message(AuthorRole.Assistant, content));
 
     /// <summary>
     /// Add a user message to the chat history.
@@ -288,7 +288,7 @@ public class ChatSession
     /// <param name="content"></param>
     /// <returns></returns>
     public ChatSession AddUserMessage(string content)
-        => AddMessage(new ChatHistory.Message(AuthorRole.User, content));
+        => AddMessage(new Message(AuthorRole.User, content));
 
     /// <summary>
     /// Remove the last message from the chat history.
@@ -305,7 +305,7 @@ public class ChatSession
     /// </summary>
     /// <param name="message"></param>
     /// <returns></returns>
-    public async Task<ChatSession> AddAndProcessMessage(ChatHistory.Message message)
+    public async Task<ChatSession> AddAndProcessMessage(Message message)
     {
         if (Executor is not StatefulExecutorBase statefulExecutor)
         {
@@ -329,19 +329,19 @@ public class ChatSession
     /// Compute KV cache for the system message and add it to the chat history.
     /// </summary>
     public Task<ChatSession> AddAndProcessSystemMessage(string content)
-        => AddAndProcessMessage(new ChatHistory.Message(AuthorRole.System, content));
+        => AddAndProcessMessage(new Message(AuthorRole.System, content));
 
     /// <summary>
     /// Compute KV cache for the user message and add it to the chat history.
     /// </summary>
     public Task<ChatSession> AddAndProcessUserMessage(string content)
-        => AddAndProcessMessage(new ChatHistory.Message(AuthorRole.User, content));
+        => AddAndProcessMessage(new Message(AuthorRole.User, content));
 
     /// <summary>
     /// Compute KV cache for the assistant message and add it to the chat history.
     /// </summary>
     public Task<ChatSession> AddAndProcessAssistantMessage(string content)
-        => AddAndProcessMessage(new ChatHistory.Message(AuthorRole.Assistant, content));
+        => AddAndProcessMessage(new Message(AuthorRole.Assistant, content));
 
     /// <summary>
     /// Replace a user message with a new message and remove all messages after the new message.
@@ -351,8 +351,8 @@ public class ChatSession
     /// <param name="newMessage"></param>
     /// <returns></returns>
     public ChatSession ReplaceUserMessage(
-        ChatHistory.Message oldMessage,
-        ChatHistory.Message newMessage)
+        Message oldMessage,
+        Message newMessage)
     {
         if (oldMessage.AuthorRole != AuthorRole.User)
         {
@@ -388,7 +388,7 @@ public class ChatSession
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
     public async IAsyncEnumerable<string> ChatAsync(
-        ChatHistory.Message message,
+        Message message,
         bool applyInputTransformPipeline,
         IInferenceParams? inferenceParams = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -460,7 +460,7 @@ public class ChatSession
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public IAsyncEnumerable<string> ChatAsync(
-        ChatHistory.Message message,
+        Message message,
         IInferenceParams? inferenceParams = null,
         CancellationToken cancellationToken = default)
     {
@@ -486,11 +486,11 @@ public class ChatSession
         IInferenceParams? inferenceParams = null,
         CancellationToken cancellationToken = default)
     {
-        ChatHistory.Message lastMessage = history.Messages.LastOrDefault()
+        Message lastMessage = history.Messages.LastOrDefault()
             ?? throw new ArgumentException("History must contain at least one message", nameof(history));
 
         foreach (
-            ChatHistory.Message message
+            Message message
             in history.Messages.Take(history.Messages.Count - 1))
         {
             // Apply input transform pipeline
@@ -546,7 +546,7 @@ public class ChatSession
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Make sure the last message is an assistant message (reponse from the LLM).
-        ChatHistory.Message? lastAssistantMessage = History.Messages.LastOrDefault();
+        Message? lastAssistantMessage = History.Messages.LastOrDefault();
 
         if (lastAssistantMessage is null
             || lastAssistantMessage.AuthorRole != AuthorRole.Assistant)
@@ -558,7 +558,7 @@ public class ChatSession
         RemoveLastMessage();
 
         // Get the last user message.
-        ChatHistory.Message? lastUserMessage = History.Messages.LastOrDefault();
+        Message? lastUserMessage = History.Messages.LastOrDefault();
 
         if (lastUserMessage is null
             || lastUserMessage.AuthorRole != AuthorRole.User)
@@ -629,11 +629,11 @@ public record SessionState
     /// The history transform used in this session.
     /// </summary>
     public IHistoryTransform HistoryTransform { get; set; } = new LLamaTransforms.DefaultHistoryTransform();
-    
+
     /// <summary>
     /// The the chat history messages for this session.
     /// </summary>
-    public ChatHistory.Message[] History { get; set; } = Array.Empty<ChatHistory.Message>();
+    public Message[] History { get; set; } = Array.Empty<Message>();
 
     /// <summary>
     /// Create a new session state.
@@ -645,7 +645,7 @@ public record SessionState
     /// <param name="outputTransform"></param>
     /// <param name="historyTransform"></param>
     public SessionState(
-        State? contextState, ExecutorBaseState executorState, 
+        State? contextState, ExecutorBaseState executorState,
         ChatHistory history, List<ITextTransform> inputTransformPipeline,
         ITextStreamTransform outputTransform, IHistoryTransform historyTransform)
     {
@@ -717,7 +717,7 @@ public record SessionState
         }
 
         string modelStateFilePath = Path.Combine(path, ChatSession.MODEL_STATE_FILENAME);
-        var contextState = File.Exists(modelStateFilePath) ? 
+        var contextState = File.Exists(modelStateFilePath) ?
             State.FromByteArray(File.ReadAllBytes(modelStateFilePath))
             : null;
 
@@ -733,7 +733,7 @@ public record SessionState
         ITextTransform[] inputTransforms;
         try
         {
-            inputTransforms = File.Exists(inputTransformFilepath) ? 
+            inputTransforms = File.Exists(inputTransformFilepath) ?
                 (JsonSerializer.Deserialize<ITextTransform[]>(File.ReadAllText(inputTransformFilepath))
                 ?? throw new ArgumentException("Input transform file is invalid", nameof(path)))
                 : Array.Empty<ITextTransform>();
@@ -744,11 +744,10 @@ public record SessionState
         }
 
         string outputTransformFilepath = Path.Combine(path, ChatSession.OUTPUT_TRANSFORM_FILENAME);
-        
         ITextStreamTransform outputTransform;
         try
         {
-            outputTransform = File.Exists(outputTransformFilepath) ? 
+            outputTransform = File.Exists(outputTransformFilepath) ?
             (JsonSerializer.Deserialize<ITextStreamTransform>(File.ReadAllText(outputTransformFilepath))
                        ?? throw new ArgumentException("Output transform file is invalid", nameof(path)))
             : new LLamaTransforms.EmptyTextOutputStreamTransform();
@@ -762,7 +761,7 @@ public record SessionState
         IHistoryTransform historyTransform;
         try
         {
-            historyTransform = File.Exists(historyTransformFilepath) ? 
+            historyTransform = File.Exists(historyTransformFilepath) ?
                 (JsonSerializer.Deserialize<IHistoryTransform>(File.ReadAllText(historyTransformFilepath))
                            ?? throw new ArgumentException("History transform file is invalid", nameof(path)))
                 : new LLamaTransforms.DefaultHistoryTransform();

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -35,39 +35,65 @@ namespace LLama.Common
     /// <summary>
     /// The chat history class
     /// </summary>
-    public class ChatHistory
+    public class Message
     {
-        private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+        /// <summary>
+        /// Role of the message author, e.g. user/assistant/system
+        /// </summary>
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("author_role")]
+        public AuthorRole AuthorRole { get; set; }
 
         /// <summary>
-        /// Chat message representation
+        /// Message content
         /// </summary>
-        public class Message
+        [JsonPropertyName("content")]
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Create a new instance
+        /// </summary>
+        /// <param name="authorRole">Role of message author</param>
+        /// <param name="content">Message content</param>
+        public Message(AuthorRole authorRole, string content)
         {
-            /// <summary>
-            /// Role of the message author, e.g. user/assistant/system
-            /// </summary>
-            [JsonConverter(typeof(JsonStringEnumConverter))]
-            [JsonPropertyName("author_role")]
-            public AuthorRole AuthorRole { get; set; }
-
-            /// <summary>
-            /// Message content
-            /// </summary>
-            [JsonPropertyName("content")]
-            public string Content { get; set; }
-
-            /// <summary>
-            /// Create a new instance
-            /// </summary>
-            /// <param name="authorRole">Role of message author</param>
-            /// <param name="content">Message content</param>
-            public Message(AuthorRole authorRole, string content)
-            {
-                this.AuthorRole = authorRole;
-                this.Content = content;
-            }
+            this.AuthorRole = authorRole;
+            this.Content = content;
         }
+    }
+
+    /// <summary>
+    /// Interface for chat history
+    /// </summary>
+    public interface IChatHistory
+    {
+        /// <summary>
+        /// List of messages in the chat
+        /// </summary>
+        List<Message> Messages { get; set; }
+
+        /// <summary>
+        /// Add a message to the chat history
+        /// </summary>
+        /// <param name="authorRole">Role of the message author</param>
+        /// <param name="content">Message content</param>
+        void AddMessage(AuthorRole authorRole, string content);
+
+        /// <summary>
+        /// Serialize the chat history to JSON
+        /// </summary>
+        /// <returns></returns>
+        string ToJson();
+    }
+
+
+    // copy from semantic-kernel
+    /// <summary>
+    /// The chat history class
+    /// </summary>
+    public class ChatHistory : IChatHistory
+    {
+        private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
         /// <summary>
         /// List of messages in the chat

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -33,7 +33,7 @@ namespace LLama.Common
 
     // copy from semantic-kernel
     /// <summary>
-    /// The chat history class
+    /// The message class
     /// </summary>
     public class Message
     {
@@ -78,14 +78,7 @@ namespace LLama.Common
         /// <param name="authorRole">Role of the message author</param>
         /// <param name="content">Message content</param>
         void AddMessage(AuthorRole authorRole, string content);
-
-        /// <summary>
-        /// Serialize the chat history to JSON
-        /// </summary>
-        /// <returns></returns>
-        string ToJson();
     }
-
 
     // copy from semantic-kernel
     /// <summary>
@@ -125,14 +118,22 @@ namespace LLama.Common
         {
             this.Messages.Add(new Message(authorRole, content));
         }
+    }
+
+    /// <summary>
+    /// Serializer for chat history
+    /// </summary>
+    public class ChatHistorySerializer<T> where T : IChatHistory
+    {
+        private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
         /// <summary>
         /// Serialize the chat history to JSON
         /// </summary>
         /// <returns></returns>
-        public string ToJson()
+        public static string ToJson(T chatHistory)
         {
-            return JsonSerializer.Serialize(this, _jsonOptions);
+            return JsonSerializer.Serialize(chatHistory, _jsonOptions);
         }
 
         /// <summary>
@@ -140,9 +141,9 @@ namespace LLama.Common
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        public static ChatHistory? FromJson(string json)
+        public static T? FromJson(string json)
         {
-            return JsonSerializer.Deserialize<ChatHistory>(json);
+            return JsonSerializer.Deserialize<T>(json);
         }
     }
 }

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -123,7 +123,7 @@ namespace LLama.Common
     /// <summary>
     /// Serializer for chat history
     /// </summary>
-    public class ChatHistorySerializer<T> where T : IChatHistory
+    public class ChatHistorySerializer
     {
         private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
 
@@ -131,7 +131,7 @@ namespace LLama.Common
         /// Serialize the chat history to JSON
         /// </summary>
         /// <returns></returns>
-        public static string ToJson(T chatHistory)
+        public static string ToJson(IChatHistory chatHistory)
         {
             return JsonSerializer.Serialize(chatHistory, _jsonOptions);
         }
@@ -141,9 +141,9 @@ namespace LLama.Common
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        public static T? FromJson(string json)
+        public static IChatHistory? FromJson(string json)
         {
-            return JsonSerializer.Deserialize<T>(json);
+            return JsonSerializer.Deserialize<IChatHistory>(json);
         }
     }
 }

--- a/LLama/Common/ChatHistory.cs
+++ b/LLama/Common/ChatHistory.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -140,10 +141,11 @@ namespace LLama.Common
         /// Deserialize a chat history from JSON
         /// </summary>
         /// <param name="json"></param>
+        /// <param name="type"></param>
         /// <returns></returns>
-        public static IChatHistory? FromJson(string json)
+        public static IChatHistory? FromJson(string json, Type type)
         {
-            return JsonSerializer.Deserialize<IChatHistory>(json);
+            return JsonSerializer.Deserialize(json, type) as IChatHistory;
         }
     }
 }

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -18,7 +18,7 @@ namespace LLama
         /// Uses plain text with the following format:
         /// [Author]: [Message]
         /// </summary>
-        public class DefaultHistoryTransform<T> : IHistoryTransform where T : IChatHistory
+        public class DefaultHistoryTransform : IHistoryTransform
         {
             private const string defaultUserName = "User";
             private const string defaultAssistantName = "Assistant";
@@ -58,7 +58,7 @@ namespace LLama
             /// <inheritdoc />
             public IHistoryTransform Clone()
             {
-                return (IHistoryTransform)new DefaultHistoryTransform<T>(_userName, _assistantName, _systemName, _unknownName, _isInstructMode);
+                return new DefaultHistoryTransform(_userName, _assistantName, _systemName, _unknownName, _isInstructMode);
             }
 
             /// <inheritdoc />
@@ -88,9 +88,9 @@ namespace LLama
             }
 
             /// <inheritdoc />
-            public virtual IChatHistory TextToHistory(AuthorRole role, string text)
+            public virtual IChatHistory TextToHistory(AuthorRole role, string text, Type type)
             {
-                T history = Activator.CreateInstance<T>();
+                IChatHistory history = (IChatHistory)(Activator.CreateInstance(type) ?? new ChatHistory());
                 history.AddMessage(role, TrimNamesFromText(text, role));
                 return history;
             }

--- a/LLama/LLamaTransforms.cs
+++ b/LLama/LLamaTransforms.cs
@@ -1,5 +1,6 @@
 ﻿using LLama.Abstractions;
 using LLama.Common;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,7 +18,7 @@ namespace LLama
         /// Uses plain text with the following format:
         /// [Author]: [Message]
         /// </summary>
-        public class DefaultHistoryTransform : IHistoryTransform
+        public class DefaultHistoryTransform<T> : IHistoryTransform where T : IChatHistory
         {
             private const string defaultUserName = "User";
             private const string defaultAssistantName = "Assistant";
@@ -44,7 +45,7 @@ namespace LLama
             /// <param name="systemName"></param>
             /// <param name="unknownName"></param>
             /// <param name="isInstructMode"></param>
-            public DefaultHistoryTransform(string? userName = null, string? assistantName = null, 
+            public DefaultHistoryTransform(string? userName = null, string? assistantName = null,
                 string? systemName = null, string? unknownName = null, bool isInstructMode = false)
             {
                 _userName = userName ?? defaultUserName;
@@ -57,11 +58,11 @@ namespace LLama
             /// <inheritdoc />
             public IHistoryTransform Clone()
             {
-                return new DefaultHistoryTransform(_userName, _assistantName, _systemName, _unknownName, _isInstructMode);
+                return (IHistoryTransform)new DefaultHistoryTransform<T>(_userName, _assistantName, _systemName, _unknownName, _isInstructMode);
             }
 
             /// <inheritdoc />
-            public virtual string HistoryToText(ChatHistory history)
+            public virtual string HistoryToText(IChatHistory history)
             {
                 StringBuilder sb = new();
                 foreach (var message in history.Messages)
@@ -87,9 +88,9 @@ namespace LLama
             }
 
             /// <inheritdoc />
-            public virtual ChatHistory TextToHistory(AuthorRole role, string text)
+            public virtual IChatHistory TextToHistory(AuthorRole role, string text)
             {
-                ChatHistory history = new ChatHistory();
+                T history = Activator.CreateInstance<T>();
                 history.AddMessage(role, TrimNamesFromText(text, role));
                 return history;
             }


### PR DESCRIPTION
ChatHistory handling via interface

This PR changed the way `ChatHistory` is used by abstracting it with an interface `IChatHistory`. 
This PR have **breaking changes**.

Unit tests:
```bash
Passed!  - Failed:     0, Passed:    85, Skipped:     3, Total:    88, Duration: 8 s - LLama.Unittest.dll (net8.0)
```

CHANGES:
* Chat `Message` is not an inner class of `ChatHistory` anymore
* `IChatHistory` is now introduces to allow own chat history implementations
